### PR TITLE
upgrade retrofit version to 2.9.0

### DIFF
--- a/okex-java-sdk-api-v5/pom.xml
+++ b/okex-java-sdk-api-v5/pom.xml
@@ -12,7 +12,7 @@
         <java.version>1.8</java.version>
         <netty.version>4.1.36.Final</netty.version>
         <okhttp3.version>3.10.0</okhttp3.version>
-        <retrofit2.version>2.3.0</retrofit2.version>
+        <retrofit2.version>2.9.0</retrofit2.version>
         <fastjson.version>1.2.46</fastjson.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <commons-collections.version>3.2.2</commons-collections.version>
@@ -96,14 +96,9 @@
             <version>4.1.36.Final</version>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>3.10.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.3.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
修复如下报错(okttp):
okhttp3.OkHttpClient : A connection to https://ws.okx.com:8443/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE); 参考：https://github.com/square/okhttp/issues/4399